### PR TITLE
Migrate - Alteração na montagem do script de atualização do banco

### DIFF
--- a/src/command/db/update/Eagle.Alfred.Command.DB.Update.Join.pas
+++ b/src/command/db/update/Eagle.Alfred.Command.DB.Update.Join.pas
@@ -39,7 +39,7 @@ type
     procedure MountFooter;
     procedure MountHeader;
     procedure SaveFileUpdate;
-    procedure InsertBreakLine(var Value: string);
+    function InsertBreakLine(const Value: string): string;
     procedure ShowMessageFounded(ConflictsMigrates: TDictionary<string,TList<string >> );
     procedure ShowMessageMigratesNotFounded;
     procedure ShowMessageSucessFull;
@@ -120,29 +120,32 @@ begin
 
 end;
 
-procedure TUpdateJoin.InsertBreakLine(var Value: string);
+function TUpdateJoin.InsertBreakLine(const Value: string): string;
 var
   Char, PreviousChar: string;
   NewValue: string;
   I: Integer;
 begin
 
+  NewValue := Value;
   I := 1;
 
-  while I < Value.Length do
+  while I < NewValue.Length do
   begin
 
-    Char := Value[I];
-    PreviousChar := Value[I - 1];
+    Char := NewValue[I];
+    PreviousChar := NewValue[I - 1];
 
     if Char.Equals(#9) and (not PreviousChar.Equals(#10)) and (not PreviousChar.Equals(#9)) then
-      Value.Insert(I - 1, #10)
+      NewValue.Insert(I - 1, #10)
     else
       Inc(I);
 
   end;
 
-  Value := Value.Replace(#10#9, #10);
+  NewValue := NewValue.Replace(#10#9, #10);
+
+  Result := NewValue;
 
 end;
 
@@ -181,9 +184,7 @@ begin
       if FUpdateService.indexIsIgnored(Index, Migrate) then
         continue;
 
-      SQLReplaced := SQL;
-
-      InsertBreakLine(SQLReplaced);
+      SQLReplaced := InsertBreakLine(SQL);
 
       FScripts.Add(SQLReplaced);
       FScripts.Add(#10'/* *********************************************************************** */'#10);

--- a/src/command/db/update/Eagle.Alfred.Command.DB.Update.Join.pas
+++ b/src/command/db/update/Eagle.Alfred.Command.DB.Update.Join.pas
@@ -39,6 +39,7 @@ type
     procedure MountFooter;
     procedure MountHeader;
     procedure SaveFileUpdate;
+    procedure InsertBreakLine(var Value: string);
     procedure ShowMessageFounded(ConflictsMigrates: TDictionary<string,TList<string >> );
     procedure ShowMessageMigratesNotFounded;
     procedure ShowMessageSucessFull;
@@ -119,6 +120,32 @@ begin
 
 end;
 
+procedure TUpdateJoin.InsertBreakLine(var Value: string);
+var
+  Char, PreviousChar: string;
+  NewValue: string;
+  I: Integer;
+begin
+
+  I := 1;
+
+  while I < Value.Length do
+  begin
+
+    Char := Value[I];
+    PreviousChar := Value[I - 1];
+
+    if Char.Equals(#9) and (not PreviousChar.Equals(#10)) and (not PreviousChar.Equals(#9)) then
+      Value.Insert(I - 1, #10)
+    else
+      Inc(I);
+
+  end;
+
+  Value := Value.Replace(#10#9, #10);
+
+end;
+
 procedure TUpdateJoin.JoinMigrates;
 begin
 
@@ -134,7 +161,7 @@ procedure TUpdateJoin.MountBody;
 var
   Migrate: TMigrate;
   Index: Integer;
-  SQL: String;
+  SQL, SQLReplaced: String;
 begin
 
   for Migrate in FMigrates do
@@ -154,11 +181,20 @@ begin
       if FUpdateService.indexIsIgnored(Index, Migrate) then
         continue;
 
-      FScripts.Add(SQL);
+      SQLReplaced := SQL;
+
+      InsertBreakLine(SQLReplaced);
+
+      FScripts.Add(SQLReplaced);
+      FScripts.Add(#10'/* *********************************************************************** */'#10);
 
       Inc(Index);
 
     end;
+
+    FScripts.Add('');
+    FScripts.Add('COMMIT WORK;');
+    FScripts.Add('');
 
   end;
 

--- a/src/migrate/service/Eagle.Alfred.Migrate.Service.MigrateService.pas
+++ b/src/migrate/service/Eagle.Alfred.Migrate.Service.MigrateService.pas
@@ -159,7 +159,7 @@ begin
       begin
 
         FileValue := TFile.ReadAllText(Format('%s%s', [FPackage.MigrationDir, FileName]));
-        FileValue := FileValue.Replace(#13#10, '');
+        FileValue := FileValue.Replace(#13#10, #9);
 
         ListMigrates.Add(TJSON.Parse<TMigrate>(FileValue));
 


### PR DESCRIPTION
Para que seja possível manter a formatação quanto a quebra de linha o carregamento dos migrates foi alterado para substituir os caracteres de quebra de linha pelo de tab(#9 - único encontrado que aceita realizar o parse), e assim ao montar o script de atualização são realizados tratamento para que o caractere seja trocado pelo de quebra de linha, tendo em vista demais tabs que possa possuir o script.