### PR TITLE
Implementação de comando migrate list

### DIFF
--- a/packages/Alfred.dpr
+++ b/packages/Alfred.dpr
@@ -56,7 +56,8 @@ uses
   Eagle.Alfred.Command.Common.Downloaders.SourceForgeDownloader in '..\src\command\common\downloader\Eagle.Alfred.Command.Common.Downloaders.SourceForgeDownloader.pas',
   Eagle.Alfred.Command.Common.Migrate.Model in '..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Model.pas',
   Eagle.Alfred.Command.Common.Migrate.Repository in '..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Repository.pas',
-  Eagle.Alfred.Command.Common.Migrate.Service in '..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Service.pas';
+  Eagle.Alfred.Command.Common.Migrate.Service in '..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Service.pas',
+  Eagle.Alfred.Command.DB.Migrate.List in '..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.List.pas';
 
 var
   OldColor: Byte;

--- a/packages/Alfred.dproj
+++ b/packages/Alfred.dproj
@@ -68,7 +68,11 @@
         <DCC_RemoteDebug>true</DCC_RemoteDebug>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
-        <Debugger_RunParams>generate migrate EG-456 author=marcos desc=&quot;teste fasdfa&quot;</Debugger_RunParams>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Build>39</VerInfo_Build>
+        <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.39;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <Debugger_RunParams>db:migrate list 1.0.0</Debugger_RunParams>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
     </PropertyGroup>
@@ -131,6 +135,7 @@
         <DCCReference Include="..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Model.pas"/>
         <DCCReference Include="..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Repository.pas"/>
         <DCCReference Include="..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Service.pas"/>
+        <DCCReference Include="..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.List.pas"/>
         <RcItem Include="..\resources\gitignore.txt">
             <ContainerId>ResourceItem</ContainerId>
             <ResourceType>RCDATA</ResourceType>
@@ -182,8 +187,8 @@
                     <Source Name="MainSource">Alfred.dpr</Source>
                 </Source>
                 <Excluded_Packages>
-                    <Excluded_Packages Name="C:\development\components\ACBr\Lib\Delphi\LibD22\ACBr_Integrador.bpl">ACBrIntegrador</Excluded_Packages>
-                    <Excluded_Packages Name="$(BDSBIN)\dclDataSnapNativeServer220.bpl">Embarcadero DBExpress DataSnap Native Server Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\bcboffice2k220.bpl">Embarcadero C++Builder Office 2000 Servers Package</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\bcbofficexp220.bpl">Embarcadero C++Builder Office XP Servers Package</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dcloffice2k220.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dclofficexp220.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
                 </Excluded_Packages>
@@ -581,13 +586,13 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
             </Deployment>
             <Platforms>
                 <Platform value="Win32">True</Platform>

--- a/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Model.pas
+++ b/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Model.pas
@@ -14,6 +14,9 @@ type
     [DISABLE]
     Name: string;
 
+    [DISABLE]
+    WasExecuted: Boolean;
+
     [Alias('issue')]
     Issue: string;
 

--- a/src/command/db/migrate/Eagle.Alfred.Command.DB.Migrate.List.pas
+++ b/src/command/db/migrate/Eagle.Alfred.Command.DB.Migrate.List.pas
@@ -1,0 +1,112 @@
+unit Eagle.Alfred.Command.DB.Migrate.List;
+
+interface
+
+uses
+  SysUtils, StrUtils,
+  System.Generics.Collections,
+
+  Eagle.Alfred,
+  Eagle.Alfred.Core.Attributes,
+  Eagle.Alfred.Core.Command,
+  Eagle.Alfred.Core.Exceptions,
+  Eagle.Alfred.Command.Common.Migrate.Model,
+
+  Eagle.Alfred.Command.Common.Migrate.Service;
+
+type
+
+  [Command('db:migrate', 'list', 'List Migrates')]
+  TMigrateListCommand = class(TCommandAbstract)
+  private
+    FMigrateService: IMigrateService;
+
+    FVersion: string;
+    procedure DoShowHeader;
+    procedure DoShowFooter;
+
+  public
+    procedure Execute(); override;
+    procedure Init(); override;
+
+    [Param(1, 'Version filter', False)]
+    procedure SetVersion(const Version: string);
+
+  end;
+
+implementation
+
+procedure TMigrateListCommand.Execute;
+var
+  FMigrates: TList<TMigrate>;
+  Migrate: TMigrate;
+  DescriptionMigrate: string;
+begin
+  inherited;
+
+  if FVersion.IsEmpty then
+    FMigrates := FMigrateService.GetMigratesByMigrationDir()
+  else
+    FMigrates := FMigrateService.GetMigratesByVersion(FVersion);
+
+  try
+
+    if (not Assigned(FMigrates)) or (FMigrates.Count = 0) then
+      raise EMigrationsNotFoundException.Create('No migration found');
+
+    DoShowHeader;
+
+    for Migrate in FMigrates do
+    begin
+
+      DescriptionMigrate := Migrate.Id.PadRight(17, ' ') + Migrate.Issue.PadRight(14, ' ') + Migrate.Version.PadRight(14, ' ') +
+      Migrate.Author.Substring(0, 15).PadRight(17, ' ') + IfThen(Migrate.WasExecuted, 'Executed', 'Not Executed');
+
+      if Migrate.WasExecuted then
+        FConsoleIO.WriteSuccessFmt('| %s', [DescriptionMigrate])
+      else
+        FConsoleIO.WriteInfoFmt('| %s', [DescriptionMigrate]);
+
+    end;
+
+    DoShowFooter;
+
+  finally
+
+    if Assigned(FMigrates) then
+      FMigrates.Free();
+
+  end;
+
+end;
+
+procedure TMigrateListCommand.Init;
+begin
+  inherited;
+  FMigrateService := TMigrateService.Create(FPackage);
+end;
+
+procedure TMigrateListCommand.SetVersion(const Version: string);
+begin
+  FVersion := Version;
+end;
+
+procedure TMigrateListCommand.DoShowFooter;
+begin
+  FConsoleIO.WriteAlert('| ');
+  FConsoleIO.WriteAlert('* ---------------------------------------------------------------------- ');
+end;
+
+procedure TMigrateListCommand.DoShowHeader;
+begin
+  FConsoleIO.WriteAlert(sLineBreak + '* -------------------------');
+  FConsoleIO.WriteAlert('| MIGRATES');
+  FConsoleIO.WriteAlert('* ---------------------------------------------------------------------- ');
+  FConsoleIO.WriteAlert('| ID               ISSUE         VERSION       AUTHOR           STATUS' + sLineBreak + '|');
+end;
+
+initialization
+
+TAlfred.GetInstance.Register(TMigrateListCommand);
+
+end.

--- a/src/core/Eagle.Alfred.Core.ConsoleIO.pas
+++ b/src/core/Eagle.Alfred.Core.ConsoleIO.pas
@@ -1,6 +1,7 @@
 unit Eagle.Alfred.Core.ConsoleIO;
 
 interface
+
 uses
   System.SysUtils,
   System.StrUtils,
@@ -8,37 +9,41 @@ uses
 
 type
 
-   IConsoleIO = interface
-      ['{53469311-2F04-4568-9928-5E85CB2822EC}']
-      procedure WriteInfo(const Msg : string);
-      procedure WriteError(const Msg : string);
-      procedure WriteProcess(const Msg : string);
-      procedure WriteSuccess(const Msg: string);
-      procedure WriteSuccessFmt(const Msg: string; const Args: array of const);
-      function ReadInfo(const Msg: String; Color: Byte = LightGray): String;
-      procedure WriteAlert(const msg: String);
-      function ReadData(const Msg: string): string;
-      function ReadBoolean(const Msg: string; const Default: Boolean): Boolean;
-   end;
+  IConsoleIO = interface
+    ['{53469311-2F04-4568-9928-5E85CB2822EC}']
+    procedure WriteInfo(const Msg: string);
+    procedure WriteInfoFmt(const Msg: string; const Args: array of const);
+    procedure WriteError(const Msg: string);
+    procedure WriteProcess(const Msg: string);
+    procedure WriteSuccess(const Msg: string);
+    procedure WriteSuccessFmt(const Msg: string; const Args: array of const);
+    function ReadInfo(const Msg: String; Color: Byte = LightGray): String;
+    procedure WriteAlert(const Msg: String);
+    function ReadData(const Msg: string): string;
+    function ReadBoolean(const Msg: string; const Default: Boolean): Boolean;
+  end;
 
-   TConsoleIO = class(TInterfacedObject, IConsoleIO)
-   private
-      procedure WriteColor(const Text: string; Color: Byte; const NewLine : Boolean = True);
-   public
-      function ReadInfo(const Msg: String; Color: Byte = LightGray): String;
-      procedure WriteAlert(const msg: String);
-      procedure WriteInfo(const Msg : string);
-      procedure WriteError(const Msg : string);
-      procedure WriteProcess(const Msg : string);
-      procedure WriteSuccess(const Msg: string);
-      procedure WriteSuccessFmt(const Msg: string; const Args: array of const);
-      function ReadData(const Msg: string): string;
-      function ReadBoolean(const Msg: string; const Default: Boolean): Boolean;
-   end;
+  TConsoleIO = class(TInterfacedObject, IConsoleIO)
+  private
+    procedure WriteColor(const Text: string; Color: Byte;
+      const NewLine: Boolean = True);
+  public
+    function ReadInfo(const Msg: String; Color: Byte = LightGray): String;
+    procedure WriteAlert(const Msg: String);
+    procedure WriteInfo(const Msg: string);
+    procedure WriteInfoFmt(const Msg: string; const Args: array of const);
+    procedure WriteError(const Msg: string);
+    procedure WriteProcess(const Msg: string);
+    procedure WriteSuccess(const Msg: string);
+    procedure WriteSuccessFmt(const Msg: string; const Args: array of const);
+    function ReadData(const Msg: string): string;
+    function ReadBoolean(const Msg: string; const Default: Boolean): Boolean;
+  end;
 
 implementation
 
-function TConsoleIO.ReadBoolean(const Msg: string; const Default: Boolean): Boolean;
+function TConsoleIO.ReadBoolean(const Msg: string;
+  const Default: Boolean): Boolean;
 var
   Value: string;
 begin
@@ -49,7 +54,7 @@ begin
     if MatchStr(Value, ['', 'yes', 'y', 'no', 'n']) then
       Break;
 
-     WriteColor('Please answer yes, y, no or n', Red);
+    WriteColor('Please answer yes, y, no or n', Red);
   until (False);
 
   if Value.IsEmpty then
@@ -64,19 +69,21 @@ begin
   Readln(Result);
 end;
 
-function TConsoleIO.ReadInfo(const Msg: String; Color: Byte = LightGray): String;
+function TConsoleIO.ReadInfo(const Msg: String;
+  Color: Byte = LightGray): String;
 begin
   WriteColor(Msg, Color);
   Result := ReadKey;
 
 end;
 
-procedure TConsoleIO.WriteAlert(const msg: String);
+procedure TConsoleIO.WriteAlert(const Msg: String);
 begin
-   WriteColor(Msg, Yellow);
+  WriteColor(Msg, Yellow);
 end;
 
-procedure TConsoleIO.WriteColor(const Text: string; Color: Byte; const NewLine : Boolean = True);
+procedure TConsoleIO.WriteColor(const Text: string; Color: Byte;
+  const NewLine: Boolean = True);
 var
   OldColor: Byte;
 begin
@@ -95,26 +102,32 @@ end;
 
 procedure TConsoleIO.WriteError(const Msg: string);
 begin
-   WriteColor(Msg, Red);
+  WriteColor(Msg, Red);
 end;
 
 procedure TConsoleIO.WriteInfo(const Msg: string);
 begin
-   WriteColor(Msg, LightGray);
+  WriteColor(Msg, LightGray);
+end;
+
+procedure TConsoleIO.WriteInfoFmt(const Msg: string; const Args: array of const);
+begin
+  WriteInfo(string.Format(Msg, Args));
 end;
 
 procedure TConsoleIO.WriteProcess(const Msg: string);
 begin
-   GotoXY(WhereX - (WhereX -1), WhereY);
-   WriteColor(Msg, LightGray, False);
+  GotoXY(WhereX - (WhereX - 1), WhereY);
+  WriteColor(Msg, LightGray, False);
 end;
 
 procedure TConsoleIO.WriteSuccess(const Msg: string);
 begin
-   WriteColor(Msg, Green);
+  WriteColor(Msg, Green);
 end;
 
-procedure TConsoleIO.WriteSuccessFmt(const Msg: string; const Args: array of const);
+procedure TConsoleIO.WriteSuccessFmt(const Msg: string;
+  const Args: array of const);
 begin
   WriteSuccess(string.Format(Msg, Args));
 end;


### PR DESCRIPTION
Implementado comando que lista os migrates existentes na pasta de migrates.

Na lista são exibidas as seguintes informações: id, issue, versão, autor e status (executado ou não executado)
Os migrates já executados ficam destacados com a cor verde, enquanto os demais ficam cm a cor branca
É possível filtrar por versão, sendo o filtro opcional