### PR TITLE
Comando Migrate Delete

### DIFF
--- a/packages/Alfred.dpr
+++ b/packages/Alfred.dpr
@@ -57,7 +57,8 @@ uses
   Eagle.Alfred.Command.Common.Migrate.Model in '..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Model.pas',
   Eagle.Alfred.Command.Common.Migrate.Repository in '..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Repository.pas',
   Eagle.Alfred.Command.Common.Migrate.Service in '..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Service.pas',
-  Eagle.Alfred.Command.DB.Migrate.List in '..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.List.pas';
+  Eagle.Alfred.Command.DB.Migrate.List in '..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.List.pas',
+  Eagle.Alfred.Command.DB.Migrate.Delete in '..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.Delete.pas';
 
 var
   OldColor: Byte;

--- a/packages/Alfred.dproj
+++ b/packages/Alfred.dproj
@@ -69,10 +69,10 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Build>39</VerInfo_Build>
+        <VerInfo_Build>49</VerInfo_Build>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.39;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <Debugger_RunParams>db:migrate list 1.0.0</Debugger_RunParams>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.49;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <Debugger_RunParams>db:migrate delete 154905241989</Debugger_RunParams>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
     </PropertyGroup>
@@ -136,6 +136,7 @@
         <DCCReference Include="..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Repository.pas"/>
         <DCCReference Include="..\src\command\common\migrate\Eagle.Alfred.Command.Common.Migrate.Service.pas"/>
         <DCCReference Include="..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.List.pas"/>
+        <DCCReference Include="..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.Delete.pas"/>
         <RcItem Include="..\resources\gitignore.txt">
             <ContainerId>ResourceItem</ContainerId>
             <ResourceType>RCDATA</ResourceType>
@@ -586,12 +587,12 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
             </Deployment>
             <Platforms>

--- a/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
+++ b/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
@@ -220,7 +220,7 @@ begin
 
     FFDConnection.GetConnection.GetTableNames('', '', '', TablesNameList);
 
-    TableMigrateExists := TablesNameList.IndexOf('MIGRATIONS') > 0;
+    TableMigrateExists := TablesNameList.IndexOf('MIGRATIONS') >= 0;
 
   finally
     TablesNameList.Free();

--- a/src/command/db/migrate/Eagle.Alfred.Command.DB.Migrate.Delete.pas
+++ b/src/command/db/migrate/Eagle.Alfred.Command.DB.Migrate.Delete.pas
@@ -1,0 +1,95 @@
+unit Eagle.Alfred.Command.DB.Migrate.Delete;
+
+interface
+
+uses
+  SysUtils,
+  System.Generics.Collections,
+
+  Eagle.Alfred,
+  Eagle.Alfred.Core.Attributes,
+  Eagle.Alfred.Core.Command,
+  Eagle.Alfred.Core.Exceptions,
+  Eagle.Alfred.Core.Enums,
+
+  Eagle.Alfred.Command.Common.Migrate.Model,
+
+  Eagle.Alfred.Command.Common.Migrate.Service,
+  Eagle.Alfred.Command.Common.Migrate.Repository;
+
+type
+
+  [Command('db:migrate', 'delete', 'Delete Migrates')]
+  TMigrateDeleteCommand = class(TCommandAbstract)
+  private
+
+    FMigrateIdentifier: string;
+    FMigrateService: IMigrateService;
+    FMigrateRepository: IMigrateRepository;
+
+  public
+
+    procedure Execute(); override;
+    procedure Init(); override;
+
+    [Param(1, 'Migrate Identifier', True)]
+    procedure SetMigrateIdentifier(const MigrateIdentifier: string);
+
+  end;
+
+implementation
+
+procedure TMigrateDeleteCommand.Execute;
+const
+  AUTO_COMMIT = True;
+var
+  Migrate: TMigrate;
+  Answer: Boolean;
+  FileName: string;
+begin
+  inherited;
+
+  Answer := False;
+  Migrate := FMigrateService.GetMigrateByIdentifier(FMigrateIdentifier);
+
+  if Migrate.Id.IsEmpty then
+    raise EMigrationsNotFoundException.Create('No migration found');
+
+  if Migrate.WasExecuted then
+    Answer := FConsoleIO.ReadBoolean(sLineBreak + 'This Migrate already executed. Do you want to run the migrate in down mode?', False);
+
+  if Answer then
+    FMigrateRepository.ExecuteMigrate(Migrate, TDown, AUTO_COMMIT);
+
+  FileName := Format('%s%s', [FPackage.MigrationDir, Migrate.Name]);
+
+  try
+    DeleteFile(FileName);
+  except
+
+    on E: Exception do
+      raise EAlfredDeleteFileException.Create(E.Message);
+
+  end;
+
+  DoShowMessageSuccessful('Migrate removed sucessfull.');
+
+end;
+
+procedure TMigrateDeleteCommand.Init;
+begin
+  inherited;
+  FMigrateService := TMigrateService.Create(FPackage);
+  FMigrateRepository := TMigrateRepository.Create(FPackage);
+end;
+
+procedure TMigrateDeleteCommand.SetMigrateIdentifier(const MigrateIdentifier: string);
+begin
+  FMigrateIdentifier := MigrateIdentifier;
+end;
+
+initialization
+
+TAlfred.GetInstance.Register(TMigrateDeleteCommand);
+
+end.

--- a/src/core/Eagle.Alfred.Core.Exceptions.pas
+++ b/src/core/Eagle.Alfred.Core.Exceptions.pas
@@ -17,6 +17,8 @@ type
 
   EAlfredCreateFileException = class(EAlfredException);
 
+  EAlfredDeleteFileException = class(EAlfredException);
+
   EDataBaseException = class(EAlfredException);
 
   EFileNotFoundException = class(EAlfredException);


### PR DESCRIPTION
Implementado comando que realiza a remoção de migrates. Em que o usuário podera informar o id ou nome completo do arquivo. Caso o migrate nao seja encontrado sera alertado que nenhum migrate foi encontrado. Caso o migrate ja tenha sido executado o usuário sera questionado se ele deseja executar o migrate em modo down, caso o usuário opte por sim o sql que constar no array down sera executado e o migrate sera removido da tabela migrates. No final o arquivo sera removido da pasta migrates.