### PR TITLE
Correção em execução de script endentado por migrate

### DIFF
--- a/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
+++ b/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
@@ -106,7 +106,7 @@ begin
       if SQL.Trim().IsEmpty() then
         continue;
 
-      FDQuery.ExecSQL(SQL);
+      FDQuery.ExecSQL(SQL.Replace(#9#9, #13#10));
 
       if IsAutoCommit then
         FFDConnection.GetConnection.Commit;


### PR DESCRIPTION
Alterada execução de scripts SQL para substituir caracteres ASCII de modo que a endentação seja mantida