### PR TITLE
Corrigida execução de migrates

### DIFF
--- a/packages/Alfred.dpr
+++ b/packages/Alfred.dpr
@@ -59,7 +59,9 @@ uses
   Eagle.Alfred.Command.DB.Migrate.Delete in '..\src\command\db\migrate\Eagle.Alfred.Command.DB.Migrate.Delete.pas',
   Eagle.Alfred.Command.Common.DependencyResolver in '..\src\command\common\Eagle.Alfred.Command.Common.DependencyResolver.pas',
   Eagle.Alfred.Command.Common.DprojParser in '..\src\command\common\Eagle.Alfred.Command.Common.DprojParser.pas',
-  Eagle.Alfred.Command.Common.DownloaderFactory in '..\src\command\common\Eagle.Alfred.Command.Common.DownloaderFactory.pas';
+  Eagle.Alfred.Command.Common.DownloaderFactory in '..\src\command\common\Eagle.Alfred.Command.Common.DownloaderFactory.pas',
+  Eagle.Alfred.Command.Common.Service.ScaperJSON in '..\src\command\common\service\Eagle.Alfred.Command.Common.Service.ScaperJSON.pas',
+  Eagle.Alfred.Commom.Utils.GroupExtractorRegularExpression in '..\src\commom\utils\Eagle.Alfred.Commom.Utils.GroupExtractorRegularExpression.pas';
 
 var
   OldColor: Byte;

--- a/packages/Alfred.dproj
+++ b/packages/Alfred.dproj
@@ -68,11 +68,11 @@
         <DCC_RemoteDebug>true</DCC_RemoteDebug>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
-        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.15;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.61;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Build>51</VerInfo_Build>
+        <VerInfo_Build>61</VerInfo_Build>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <Debugger_RunParams>uninstall paolo-rossi/delphi-jose-jwt</Debugger_RunParams>
+        <Debugger_RunParams>db:migrate up</Debugger_RunParams>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
     </PropertyGroup>
@@ -138,6 +138,8 @@
         <DCCReference Include="..\src\command\common\Eagle.Alfred.Command.Common.DependencyResolver.pas"/>
         <DCCReference Include="..\src\command\common\Eagle.Alfred.Command.Common.DprojParser.pas"/>
         <DCCReference Include="..\src\command\common\Eagle.Alfred.Command.Common.DownloaderFactory.pas"/>
+        <DCCReference Include="..\src\command\common\service\Eagle.Alfred.Command.Common.Service.ScaperJSON.pas"/>
+        <DCCReference Include="..\src\commom\utils\Eagle.Alfred.Commom.Utils.GroupExtractorRegularExpression.pas"/>
         <RcItem Include="..\resources\gitignore.txt">
             <ContainerId>ResourceItem</ContainerId>
             <ResourceType>RCDATA</ResourceType>
@@ -189,9 +191,8 @@
                     <Source Name="MainSource">Alfred.dpr</Source>
                 </Source>
                 <Excluded_Packages>
-                    <Excluded_Packages Name="C:\development\components\ACBr\Lib\Delphi\LibD22\ACBr_Integrador.bpl">ACBrIntegrador</Excluded_Packages>
-                    <Excluded_Packages Name="$(BDSBIN)\dclDataSnapNativeServer220.bpl">Embarcadero DBExpress DataSnap Native Server Components</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dclIPIndyImpl220.bpl">IP Abstraction Indy Implementation Design Time</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclDataSnapNativeServer220.bpl">Embarcadero DBExpress DataSnap Native Server Components</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dcloffice2k220.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dclofficexp220.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
                 </Excluded_Packages>
@@ -589,12 +590,12 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
             </Deployment>
             <Platforms>

--- a/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
+++ b/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
@@ -8,6 +8,7 @@ uses
 
   FireDAC.Comp.Client,
   FireDAC.Comp.Script,
+  FireDAC.Stan.Param,
   FireDAC.UI.Intf,
   FireDAC.Comp.ScriptCommands,
 
@@ -96,6 +97,9 @@ begin
   else
     SQLList := Migrate.down;
 
+  FFDConnection.GetConnection.ResourceOptions.MacroCreate := False;
+  FFDConnection.GetConnection.ResourceOptions.MacroExpand := False;
+
   FFDConnection.GetConnection.StartTransaction;
 
   try
@@ -106,7 +110,9 @@ begin
       if SQL.Trim().IsEmpty() then
         continue;
 
-      FDQuery.ExecSQL(SQL);
+      FDQuery.SQL.Text := SQL.Replace(#9#9, #13#10).Replace(#9, #13#10);
+
+      FDQuery.ExecSQL();
 
       if IsAutoCommit then
         FFDConnection.GetConnection.Commit;

--- a/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Service.pas
+++ b/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Service.pas
@@ -1,5 +1,5 @@
 unit Eagle.Alfred.Command.Common.Migrate.Service;
-
+
 interface
 
 uses
@@ -18,6 +18,7 @@ uses
   Eagle.Alfred.Utils,
   Eagle.Alfred.Core.Enums,
   Eagle.Alfred.Core.Exceptions,
+  Eagle.Alfred.Command.Common.Service.ScaperJSON,
   Eagle.Alfred.Command.Common.Migrate.Model,
   Eagle.Alfred.Command.Common.Migrate.Repository;
 
@@ -54,7 +55,7 @@ type
     function GetMigratesByVersion(const Version: string): TList<TMigrate>;
     function GetMigrateByIdentifier(const Identifier: string): TMigrate;
     function MigrateDirectoryExists: Boolean;
-    procedure RemoveMigratesUnusableList(const ExecutionMode : TExecutionModeMigrate; var Migrates: TList<TMigrate>; const ListMigratesExecuted: TList<string>);
+    procedure RemoveMigratesUnusableList(const ExecutionMode: TExecutionModeMigrate; var Migrates: TList<TMigrate>; const ListMigratesExecuted: TList<string>);
   end;
 
 implementation
@@ -127,8 +128,7 @@ begin
 
   ListFiles := TList<String>.Create;
 
-  Index := FindFirst(Format('%s%s*.json', [FPackage.BaseDir,
-    FPackage.MigrationDir]), faAnyFile, Search);
+  Index := FindFirst(Format('%s%s*.json', [FPackage.BaseDir, FPackage.MigrationDir]), faAnyFile, Search);
 
   while Index = 0 do
   begin
@@ -142,7 +142,7 @@ begin
 
 end;
 
-function TMigrateService.GetMigrateByIdentifier(const Identifier: string) : TMigrate;
+function TMigrateService.GetMigrateByIdentifier(const Identifier: string): TMigrate;
 var
   Migrates: TList<TMigrate>;
   Migrate, MigrateResult: TMigrate;
@@ -158,7 +158,7 @@ begin
     for Migrate in Migrates do
     begin
 
-      if not (Migrate.Id.Equals(Identifier) or Migrate.Name.Replace('.json', '').ToUpper.Equals(Identifier.ToUpper)) then
+      if not(Migrate.Id.Equals(Identifier) or Migrate.Name.Replace('.json', '').ToUpper.Equals(Identifier.ToUpper)) then
         continue;
 
       MigrateResult := Migrates.Extract(Migrate);
@@ -235,6 +235,8 @@ begin
 
   Data := Data.Replace(#13#10, #9);
 
+  Data := TScaperJSON.Scape(Data);
+
   try
     Result := TJSON.Parse<TMigrate>(Data);
     Result.Id := FileName.Split(['_'])[0];
@@ -254,8 +256,7 @@ begin
   Result := DirectoryExists(FPackage.MigrationDir + '\');
 end;
 
-procedure TMigrateService.RemoveMigratesUnusableList(const ExecutionMode: TExecutionModeMigrate; var Migrates: TList<TMigrate>;
-  const ListMigratesExecuted: TList<string>);
+procedure TMigrateService.RemoveMigratesUnusableList(const ExecutionMode: TExecutionModeMigrate; var Migrates: TList<TMigrate>; const ListMigratesExecuted: TList<string>);
 var
   Migrate: TMigrate;
   CanRemove: Boolean;
@@ -289,3 +290,4 @@ begin
 end;
 
 end.
+

--- a/src/command/common/service/Eagle.Alfred.Command.Common.Service.ScaperJSON.pas
+++ b/src/command/common/service/Eagle.Alfred.Command.Common.Service.ScaperJSON.pas
@@ -1,0 +1,60 @@
+unit Eagle.Alfred.Command.Common.Service.ScaperJSON;
+
+interface
+
+uses
+  SysUtils, Generics.Collections,
+
+  Eagle.Alfred.Commom.Utils.GroupExtractorRegularExpression;
+
+type
+  TScaperJSON = class
+  public
+    class function Scape(const JSON: string): string;
+  end;
+
+implementation
+
+class function TScaperJSON.Scape(const JSON: string): string;
+const
+  EXPRESSION_REGULAR = '(?:\''(?<identifier>[^\'']+)\s*(?<parameters>.*?)\'')';
+  GROUP_INDEX = 1;
+  CARACTER_TO_SCAPE = '"';
+  CARACTER_SCAPED = '\"';
+var
+  JSONScaped: string;
+  SentenceToScape, SentenceScaped: string;
+  SentencesToScape: TList<string>;
+begin
+
+  SentencesToScape := TGroupExtractorRegularExpression.ExtractListGroups(EXPRESSION_REGULAR, JSON, GROUP_INDEX);
+
+  try
+
+    if SentencesToScape.Count <= 0 then
+      Exit(JSON);
+
+    JSONScaped := JSON;
+
+    for SentenceToScape in SentencesToScape do
+    begin
+
+      if not SentenceToScape.Contains(CARACTER_TO_SCAPE) then
+        continue;
+
+      SentenceScaped := SentenceToScape.Replace(CARACTER_TO_SCAPE, CARACTER_SCAPED);
+
+      JSONScaped := JSONScaped.Replace(SentenceToScape, SentenceScaped);
+
+    end;
+
+
+  finally
+    SentencesToScape.Free();
+  end;
+
+  Result := JSONScaped;
+
+end;
+
+end.

--- a/src/commom/utils/Eagle.Alfred.Commom.Utils.GroupExtractorRegularExpression.pas
+++ b/src/commom/utils/Eagle.Alfred.Commom.Utils.GroupExtractorRegularExpression.pas
@@ -1,0 +1,49 @@
+unit Eagle.Alfred.Commom.Utils.GroupExtractorRegularExpression;
+
+interface
+
+uses
+  System.RegularExpressions,
+  Generics.Collections;
+
+type
+
+  TGroupExtractorRegularExpression = class
+  public
+    class function ExtractListGroups(const RegularExpression, Value: string; const GroupIndex: Integer): TList<string>;
+  end;
+
+implementation
+
+class function TGroupExtractorRegularExpression.ExtractListGroups(const RegularExpression, Value: string; const GroupIndex: Integer): TList<string>;
+const
+  EMPTY = '';
+var
+  Extractor: TRegEx;
+  QuantidadeGrupos: Integer;
+  Matches: TMatchCollection;
+  Index: Integer;
+  ValueMatched: string;
+  ValuesMatcheds: TList<string>;
+begin
+
+  ValuesMatcheds := TList<string>.Create();
+
+  if GroupIndex < 0 then
+    Exit(ValuesMatcheds);
+
+  Extractor := TRegEx.Create(RegularExpression);
+
+  Matches := Extractor.Matches(Value);
+
+  for Index := 0 to Matches.Count - 1 do
+  begin
+    ValueMatched := Matches.Item[Index].Groups.Item[GroupIndex].Value;
+    ValuesMatcheds.Add(ValueMatched);
+  end;
+
+  Result := ValuesMatcheds;
+
+end;
+
+end.


### PR DESCRIPTION
Implementada inserção de scape nos scrips SQL que possuem aspas duplas em sua estrutura.

Para a correção foi criada a classe ScaperJSON, que retorna o JSON escapado.