### PR TITLE
AF 22 - Alteração em conexão para conversão de caracteres

### DIFF
--- a/src/command/Eagle.Alfred.Command.Init.pas
+++ b/src/command/Eagle.Alfred.Command.Init.pas
@@ -19,6 +19,7 @@ type
   TInitCommand = class(TCommandAbstract)
   private
     function CreateMessage(const Msg: string; Default: string): string;
+    procedure ReadDBCharacterSet;
     procedure ReadProjectName;
     procedure ReadDBFile;
     procedure ReadDBHost;
@@ -102,6 +103,18 @@ begin
   FPackage.TestsDir := FConfiguration.TestsDir;
   FPackage.Namespace := FConfiguration.Namespace;
   FPackage.Modular := FConfiguration.Modular;
+end;
+
+procedure TInitCommand.ReadDBCharacterSet;
+var
+  Msg, Value: string;
+begin
+  Msg := CreateMessage('characterSet: ', FPackage.DataBase.CharacterSet);
+
+  Value := ReadRequiredData(Msg, FPackage.DataBase.CharacterSet, 'characterSet required!');
+
+  if not Value.IsEmpty then
+    FPackage.DataBase.CharacterSet := Value;
 end;
 
 procedure TInitCommand.ReadDBFile;
@@ -215,12 +228,15 @@ begin
   FPackage.DataBase.User := FConfiguration.DBUser;
   FPackage.DataBase.Pass := FConfiguration.DBPass;
   FPackage.DataBase.Port := FConfiguration.DBPort;
+  FPackage.DataBase.CharacterSet := FConfiguration.CharacterSet;
 
   ReadDBHost;
   ReadDBFile;
   ReadDBUser;
   ReadDBPass;
   ReadDBPort;
+  ReadDBCharacterSet;
+
 end;
 
 procedure TInitCommand.ReadProjectDescription;

--- a/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
+++ b/src/command/common/migrate/Eagle.Alfred.Command.Common.Migrate.Repository.pas
@@ -70,7 +70,7 @@ begin
   Password := FPackage.DataBase.Pass;
   Port := string.Parse(FPackage.DataBase.Port);
 
-  FFDConnection := TFireDacFirebirdConnection.Create(HostName, DataBase, UserName, Password, Port);
+  FFDConnection := TFireDacFirebirdConnection.Create(FPackage.DataBase);
 
   FDQuery := TFDQuery.Create(nil);
   FDQuery.Connection := FFDConnection.GetConnection;

--- a/src/command/db/common/Eagle.Alfred.Command.DB.Common.FiredacConnection.pas
+++ b/src/command/db/common/Eagle.Alfred.Command.DB.Common.FiredacConnection.pas
@@ -17,6 +17,7 @@ uses
   FireDAC.Phys.FB,
   FireDAC.VCLUI.Wait,
 
+  Eagle.Alfred.Core.Types,
   Eagle.Alfred.Command.DB.Common.Connection;
 
 type
@@ -28,6 +29,7 @@ type
     FUserName: string;
     FPassword: string;
     FPort: string;
+    FCharacterSet: string;
 
     FDDriverLink: TFDPhysFBDriverLink;
     FConnection: TFDConnection;
@@ -35,7 +37,7 @@ type
     procedure CreateConnection;
 
   public
-    constructor Create(const HostName: string; const DataBase: string; const UserName: string; const Password: string; const Port: string);
+    constructor Create(const DataBaseConfig: TDataBase);
     destructor Destroy; override;
     procedure Initialize;
     procedure Release;
@@ -45,17 +47,16 @@ type
 
 implementation
 
-{ TFireDacFirebirdConnection }
-
-constructor TFireDacFirebirdConnection.Create(const HostName: string; const DataBase: string; const UserName: string; const Password: string; const Port: string);
+constructor TFireDacFirebirdConnection.Create(const DataBaseConfig: TDataBase);
 begin
   inherited Create();
 
-  FDatabase := DataBase;
-  FHostName := HostName;
-  FUserName := UserName;
-  FPassword := Password;
-  FPort := Port;
+  FDatabase := DataBaseConfig.&File;
+  FHostName := DataBaseConfig.Host;
+  FUserName := DataBaseConfig.User;
+  FPassword := DataBaseConfig.Pass;
+  FPort := DataBaseConfig.Port.ToString;
+  FCharacterSet := DataBaseConfig.CharacterSet;
 
   Initialize;
 
@@ -76,7 +77,8 @@ begin
   FConnection.Params.Add('Password=' + FPassword);
   FConnection.Params.Add('Port=' + FPort);
 
-  FConnection.Params.Add('CharacterSet=WIN1252');
+  if not FCharacterSet.IsEmpty then
+    FConnection.Params.Add('CharacterSet=' + FCharacterSet);
 
 end;
 

--- a/src/command/db/common/Eagle.Alfred.Command.DB.Common.FiredacConnection.pas
+++ b/src/command/db/common/Eagle.Alfred.Command.DB.Common.FiredacConnection.pas
@@ -76,6 +76,8 @@ begin
   FConnection.Params.Add('Password=' + FPassword);
   FConnection.Params.Add('Port=' + FPort);
 
+  FConnection.Params.Add('CharacterSet=WIN1252');
+
 end;
 
 destructor TFireDacFirebirdConnection.Destroy;

--- a/src/command/db/common/Eagle.Alfred.Command.DB.Common.Repository.pas
+++ b/src/command/db/common/Eagle.Alfred.Command.DB.Common.Repository.pas
@@ -43,8 +43,6 @@ type
 implementation
 
 constructor TRepository.Create(const APackage: TPackage);
-var
-  DataBase, HostName, UserName, Password, Port: String;
 begin
   inherited Create();
 
@@ -53,13 +51,7 @@ begin
 
   FPackage := APackage;
 
-  DataBase := FPackage.DataBase.&File;
-  HostName := FPackage.DataBase.Host;
-  UserName := FPackage.DataBase.User;
-  Password := FPackage.DataBase.Pass;
-  Port := string.Parse(FPackage.DataBase.Port);
-
-  FFDConnection := TFireDacFirebirdConnection.Create(HostName, DataBase, UserName, Password, Port);
+  FFDConnection := TFireDacFirebirdConnection.Create(FPackage.DataBase);
 
   FFDConnection.GetConnection.TxOptions.AutoCommit := False;
 

--- a/src/core/Eagle.Alfred.Core.Types.pas
+++ b/src/core/Eagle.Alfred.Core.Types.pas
@@ -46,6 +46,8 @@ type
     Pass: string;
     [Alias('port')]
     Port: Integer;
+    [Alias('character-set')]
+    CharacterSet: string;
   end;
 
   TPackage = class
@@ -148,6 +150,8 @@ type
     DBPass: string;
     [Alias('db-port')]
     DBPort: Integer;
+    [Alias('character-set')]
+    CharacterSet: string;
 
     [Alias('default-editor')]
     DefaultEditor: string;
@@ -200,6 +204,7 @@ begin
   DBUser := 'sysdba';
   DBPass := 'masterkey';
   DBPort := 3050;
+  CharacterSet := 'WIN1252';
 end;
 
 { TDependency }


### PR DESCRIPTION
O erro ocorria devido a que o motor de execução não estava conseguindo converter os caracteres com acento para o padrão esperado pelo banco, fazendo-se necessário inserir uma configuração na configuração informando que o CharacterSet esperado é o WIN1252