### PR TITLE
Correção em erro de violação de memória

### DIFF
--- a/src/core/Eagle.Alfred.Core.CommandRegister.pas
+++ b/src/core/Eagle.Alfred.Core.CommandRegister.pas
@@ -70,7 +70,8 @@ begin
 
   try
 
-    RttiType := RttiContext.GetType(CommandClass.ClassInfo);
+    RttiType := RttiContext.GetType(CommandClass);
+    RttiContext.KeepContext;
 
     if not RttiType.TryGetCustomAttribute<CommandAttribute>(CmdAttrib) then
       raise Exception.Create('CommandAttribute Not Found');


### PR DESCRIPTION
Na versão 10 a RTTI do Delphi foi totalmente reescrita, o que agregou novos recursos e travas de segurança.

Uma dessas alterações fazia com que os objetos oriundos do contexto do RTTI ficassem inutilizados após sua destruição. Mesmo assim, foi incorporado um método que permite que os objetos ficassem ativos e usáveis. Este método se chama KeepContext, e assim o Alfred foi alterado para utilizá-lo.