### PR TITLE
Implementado verificação de conflitos em migrates com PostgreSQL

### DIFF
--- a/src/command/db/update/Eagle.Alfred.Command.DB.Update.Check.pas
+++ b/src/command/db/update/Eagle.Alfred.Command.DB.Update.Check.pas
@@ -91,7 +91,7 @@ begin
   inherited;
 
   FMigrateService := TMigrateService.Create(FPackage);
-  FUpdateService := TUpdateService.Create();
+  FUpdateService := TUpdateService.Create(FPackage.DataBase.Driver);
 
 end;
 

--- a/src/command/db/update/Eagle.Alfred.Command.DB.Update.Join.pas
+++ b/src/command/db/update/Eagle.Alfred.Command.DB.Update.Join.pas
@@ -101,7 +101,7 @@ procedure TUpdateJoin.Init;
 begin
   inherited;
   FMigrateService := TMigrateService.Create(FPackage);
-  FUpdateService := TUpdateService.Create();
+  FUpdateService := TUpdateService.Create(FPackage.DataBase.Driver);
 
   FScripts := TStringList.Create();
 


### PR DESCRIPTION
**DESCRIÇÃO**

O regex utilizado para verificação de conflitos em migrates utilizando PostgreSQL não funciona corretamente pois o a sintaxe do FireBird é um pouco diferente. 

**O QUE FOI FEITO**

- Implementado Regex para verificação de conflitos com  a sintaxe do PostgreSQL
- Implementado construtor para a classe UpdateService. Esse construtor irá receber a string com o nome do Driver configurado no arquivo Package.json. Dentro do construtor será criado o Driver correspondente e quando a verificação de conflitos for realizada será observado o driver configurado e assim utilizado o regex também correspondente de cada banco de dados.
- Implementado para o regex do PostgreSQL a utilização de diferentes Schemas.

**INFORMAÇÃO ADICIONAL**

- Alteração impacta somente no funcionamento nas variações do comando `alfred db:update [check, join].`